### PR TITLE
Relax the ISA string order checking for -march

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -57,12 +57,49 @@ e.g. `-march=rv64g`. A target `-march` which includes floating point
 instructions implies a hardfloat calling convention, but can be overridden 
 using the `-mabi` flag (see the next section).
 
-The ISA subset naming conventions are described in Chapter 27 of the RISC-V 
-user-level ISA specification. However, tools do not currently follow this 
-specification (input is case sensitive, ...).
+The ISA subset naming conventions and canonical order are described in
+Chapter `ISA Extension Naming Conventions` of the RISC-V user-level ISA
+specification. However, tools do not currently follow this specification
+(input is case sensitive, ...).
+
+The rule of ISA string become more complicated, due to extensions implication
+rule and more extensions added into RISC-V, the canonical order is non-obvious
+to human, so tools can accept the ISA string in non-canonical order for reduce
+the burden of remembering the canonical order.
+
+Detail rule for ISA string:
+
+1. First letter must be `i`, `e` or `g`.
+2. Single-letter may be non-canonical order.
+3. Multi-letter may be non-canonical order.
+4. Multi-letter must be separated by underscore.
+5. Version separator(`p`) has higher priority than `p` extension.
+
+Example:
+```
+rv32ima_zicsr        # Valid ISA string.
+rv32i_zicsr_m        # Valid ISA string.
+rv32i_zicsr_ma       # Valid ISA string.
+rv32imac             # Valid ISA string.
+rv32mai              # Invalid ISA string, first letter must be `i`, `e` or `g`.
+rv32i_zicsrzifence   # Valid ISA string, but it will interpreted as rv32
+                     # with base extension and `zicsrzifence` extension
+                     # rather than `zicsr` and `zifence` extensions.
+rv32i2p1             # Valid ISA string, it recognized as `I` extension with
+                     # version 2.1 rather than `I` extension with with version
+                     # 2.0 and `P` extension with 1.0.
+```
 
 If the 'C' (compressed) instruction set extension is targeted, the compiler 
 will generate compressed instructions where possible.
+
+NOTE: Single-letter extension with version (e.g. `m2p0`) still treat as
+      single-letter extension, we won't treat it as multi-letter extension.
+
+NOTE: Any output of ISA string like `Tag_RISCV_arch` must be canonical order.
+
+NOTE: Cross-tool argument are highly recommended passed in canonical order for
+      backward compatible.
 
 ### Issues for consideration
 * Whether `riscv32` and `riscv64` should be accepted as synonyms for `rv32` 


### PR DESCRIPTION
Changes:
2021/08/16: Remove order constraint between single-letter and multi-letter, also add 2 more NOTE.

---

It's corresponding for https://github.com/riscv/riscv-toolchain-conventions/issues/11 ,