### PR TITLE
Define prefix for T-Head vendor extensions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -297,6 +297,7 @@ in the ratified base ISA and extensions (e.g. the use of 'w', 'd',
 Vendor                 | Prefix          | URL
 :--------------------- | :-------------- | :-------------
 SiFive                 | sf              | https://www.sifive.com/
+T-Head                 | th              | https://www.t-head.cn/
 Ventana Micro Systems  | vt              | https://www.ventanamicro.com/
 
 NOTE: Vendor prefixes are case-insensitive.
@@ -305,6 +306,16 @@ NOTE: Vendor prefixes are case-insensitive.
 
 Vendor  | Name            | Version        | ISA Document
 :------ | :-------------- | :------------- | :---------------
+T-Head  | XTheadCmo       | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadSync      | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadBa        | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadBb        | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadBs        | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadCondMov   | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadMac       | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadMemPair   | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadMemIdx    | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+T-Head  | XTheadFMemIdx   | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
 Ventana | XVentanaCondOps | 1.0            | [VTx-family custom instructions](https://github.com/ventanamicro/ventana-custom-extensions/releases/download/v1.0.0/ventana-custom-extensions-v1.0.0.pdf)
 
 NOTE: Vendor extension names are case-insensitive, CamelCase is used here


### PR DESCRIPTION
This PR adds a commit on top of PR #17 that introduces `th` as the instruction prefix for T-Head vendor extensions.