### PR TITLE
Vendor extensions: Add SiFive vendor extensions: xsfvcp

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -318,6 +318,7 @@ T-Head  | XTheadMac       | 2.0.0          | [T-Head ISA extension specification
 T-Head  | XTheadMemPair   | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
 T-Head  | XTheadMemIdx    | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
 T-Head  | XTheadSync      | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
+SiFive  | XSFVCP          | 1.0            | [SiFive Vector Coprocessor Interface Software Specification](https://sifive.cdn.prismic.io/sifive/c3829e36-8552-41f0-a841-79945784241b_vcix-spec-software.pdf)
 Ventana | XVentanaCondOps | 1.0            | [VTx-family custom instructions](https://github.com/ventanamicro/ventana-custom-extensions/releases/download/v1.0.0/ventana-custom-extensions-v1.0.0.pdf)
 
 NOTE: Vendor extension names are case-insensitive, CamelCase is used here


### PR DESCRIPTION
SiFive published vector coprocessor interface spec, it included assembly mnemonic, instrucion encoding and C intrinsic interface.