### PR TITLE
Vendor extensions: Fix alphabetical order

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -306,6 +306,7 @@ NOTE: Vendor prefixes are case-insensitive.
 
 Vendor  | Name            | Version        | ISA Document
 :------ | :-------------- | :------------- | :---------------
+SiFive  | XSFVCP          | 1.0            | [SiFive Vector Coprocessor Interface Software Specification](https://sifive.cdn.prismic.io/sifive/c3829e36-8552-41f0-a841-79945784241b_vcix-spec-software.pdf)
 T-Head  | XTheadCmo       | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
 T-Head  | XTheadBa        | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
 T-Head  | XTheadBb        | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
@@ -318,7 +319,6 @@ T-Head  | XTheadMac       | 2.0.0          | [T-Head ISA extension specification
 T-Head  | XTheadMemPair   | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
 T-Head  | XTheadMemIdx    | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
 T-Head  | XTheadSync      | 2.0.0          | [T-Head ISA extension specification](https://github.com/T-head-Semi/thead-extension-spec/releases/download/2.0.0/xthead-2022-09-05-2.0.0.pdf)
-SiFive  | XSFVCP          | 1.0            | [SiFive Vector Coprocessor Interface Software Specification](https://sifive.cdn.prismic.io/sifive/c3829e36-8552-41f0-a841-79945784241b_vcix-spec-software.pdf)
 Ventana | XVentanaCondOps | 1.0            | [VTx-family custom instructions](https://github.com/ventanamicro/ventana-custom-extensions/releases/download/v1.0.0/ventana-custom-extensions-v1.0.0.pdf)
 
 NOTE: Vendor extension names are case-insensitive, CamelCase is used here


### PR DESCRIPTION
A recent patch introduced the SiFive extensions at the wrong position. Let's fix that.

Signed-off-by: Christoph Müllner <christoph.muellner@vrull.eu>