### PR TITLE
Vendor extensions: Add Nuclei vendor extensions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -299,6 +299,7 @@ Vendor                 | Prefix          | URL
 SiFive                 | sf              | https://www.sifive.com/
 T-Head                 | th              | https://www.t-head.cn/
 Ventana Micro Systems  | vt              | https://www.ventanamicro.com/
+Nuclei                 | xl              | https://nucleisys.com/
 
 NOTE: Vendor prefixes are case-insensitive.
 

--- a/README.mkd
+++ b/README.mkd
@@ -301,7 +301,8 @@ T-Head                 | th              | https://www.t-head.cn/
 Ventana Micro Systems  | vt              | https://www.ventanamicro.com/
 Nuclei                 | xl              | https://nucleisys.com/
 
-NOTE: Vendor prefixes are case-insensitive.
+- NOTE: Vendor prefixes are case-insensitive.
+- NOTE: The Nuclei instruction prefix `xl` is an abbreviation of "XinLai", which is the Chinese pronunciation of Nuclei(芯来).
 
 ### List of vendor extensions
 


### PR DESCRIPTION
This patch defines the Nuclei Instruction prefix `xl`, abbreviation of XinLai(Chinese pronunciation of Nuclei 芯来科技).