### PR TITLE
Add rule for vendor CSR naming scheme

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -322,6 +322,15 @@ Vendors should also aim to follow the conventions used for naming mnemonics
 in the ratified base ISA and extensions (e.g. the use of 'w', 'd',
 'u', and 's' suffixes).
 
+### CSR naming scheme
+
+Vendors may define their own CSRs within the custom read-only CSR address range
+specified in the RISC-V ISA spec. However, to avoid conflicts, each vendor CSR
+must include a prefix corresponding to the vendor's name.
+
+The vendor prefix should match the prefix defined in assembly mnemonics and be
+separated by a dot, e.g., `th.vxrm`.
+
 ### List of vendor prefixes
 
 


### PR DESCRIPTION
In the last LLVM sync up meeting, we have dicussed the vendor CSR stuffs, and we realized that we have rule for vendor extenison name and assembly mnemonic, but no rule for vendor CSR naming scheme yet.

So it's would be great we have one before anyone start to upstream their own CSR definition.

The naming scheme basically follow the assembly mnemonic - use vendor prefix, the only difference is use underscore rather than dot, because it could be used in marco definition, but dot can't, that's an important character since that allow user to use marco before assmbler support, and eaiser to migrate to new version once assmbler support.