### PR TITLE
Remove hint for deprecating medlow

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -162,12 +162,6 @@ within a single 2GiB address range, between the absolute addresses -2GiB and
 within a single 4GiB address range. `auipc` and `addi` pairs are used to 
 generate addresses.
 
-TODO: interaction with PIC.
-
-### Issues for consideration
-* It has been proposed to deprecate the `medlow` code model and rename 
-`medany` to `medium`.
-
 ## Disassembler (objdump) behaviour
 
 A RISC-V ELF binary is not currently self-describing, in the sense that it 


### PR DESCRIPTION
A hint that medlow might get deprecated in the future is a) useless, and b) misleading.
Let's drop that.

This came up as part of https://github.com/riscv-non-isa/riscv-toolchain-conventions/issues/42.