### PR TITLE
Refer to the RISC-V C API document for preprocessor definitions

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -170,34 +170,9 @@ disable the automatic 'compression' of instructions.
 
 == C/C++ preprocessor definitions
 
-- `+__riscv+`: defined for any RISC-V target. Older versions of the GCC
-toolchain defined `+__riscv__+`.
-- `+__riscv_xlen+`: 32 for RV32 and 64 for RV64.
-- `+__riscv_float_abi_soft+`, `+__riscv_float_abi_single+`,
-`+__riscv_float_abi_double+`: one of these three will be defined, depending on
-target ABI.
-- `+__riscv_cmodel_medlow+`, `+__riscv_cmodel_medany+`,
-`+__riscv_cmodel_large+`: one of these three will be defined, depending on
-the target code model.
-- `+__riscv_mul+`: defined when targeting the 'M' ISA extension.
-- `+__riscv_muldiv+`: defined when targeting the 'M' ISA extension and
-`-mno-div` has not been used.
-- `+__riscv_div+`: defined when targeting the 'M' ISA extension and `-mno-div`
-has not been used.
-- `+__riscv_atomic+`: defined when targeting the 'A' ISA extension.
-- `+__riscv_flen+`: 32 when targeting the 'F' ISA extension (but not 'D') and 64
-when targeting 'FD'.
-- `+__riscv_fdiv+`: defined when targeting the 'F' or 'D' ISA extensions and
-`-mno-fdiv` has not been used.
-- `+__riscv_fsqrt+`: defined when targeting the 'F' or 'D' ISA extensions and
-`-mno-fdiv` has not been used.
-- `+__riscv_compressed+`: defined when targeting the 'C' ISA extension.
-
-=== Issues for consideration
-- What should the naming convention be for defines that indicate support for
-non-standard extensions?
-- What additional information could/should be exposed via preprocessor
-defines?
+These are now maintained in the
+https://github.com/riscv-non-isa/riscv-c-api-doc/blob/main/src/c-api.adoc[RISC-V
+C API specification].
 
 == Specifying stack alignment
 


### PR DESCRIPTION
The list in this document is incomplete, and the riscv-c-api-doc repo has since been created to hold this kind of information. Let's just point there rather than trying to maintain the same information in two places.

That document doesn't mention that older version of GCC defined `__riscv__` but I think this is just a historical curiousity at this point, so this isn't a real loss of information.