### PR TITLE
Vendor extensions: Add Tenstorrent vendor prefix

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -281,6 +281,7 @@ separated by a dot, e.g., `th.vxrm`.
 |Andes                  | nds             | https://www.andestech.com/
 |SiFive                 | sf              | https://www.sifive.com/
 |T-Head                 | th              | https://www.t-head.cn/
+|Tenstorrent            | tt              | https://www.tenstorrent.com/
 |Ventana Micro Systems  | vt              | https://www.ventanamicro.com/
 |Nuclei                 | xl              | https://nucleisys.com/
 |===


### PR DESCRIPTION
Hi, we'd like to reserve 'tt' as a vendor extension prefix, thanks