### PR TITLE
Add MIPS extensions

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -378,8 +378,8 @@ tag to provide extra relocations for a given vendor.
 |T-Head  | XTheadSync      | 1.0            | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |T-Head  | XTheadVector    | 1.0            | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |Ventana | XVentanaCondOps | 1.0            | https://github.com/ventanamicro/ventana-custom-extensions/releases/download/v1.0.0/ventana-custom-extensions-v1.0.0.pdf[VTx-family custom instructions]
-|MIPS    | Xmipscmove      | 1.0            | https://mips.com/products/hardware/p8700/[MIPS p8700 specification]
-|MIPS    | Xmipslsp        | 1.0            | https://mips.com/products/hardware/p8700/[MIPS p8700 specification]
+|MIPS    | Xmipscmov       | 1.0            | https://mips.com/wp-content/uploads/2025/03/P8700-F_Programmers_Reference_Manual_Rev1.82_3-19-2025.pdf[MIPS P8700 Programmer's Guide]
+|MIPS    | Xmipslsp        | 1.0            | https://mips.com/wp-content/uploads/2025/03/P8700-F_Programmers_Reference_Manual_Rev1.82_3-19-2025.pdf[MIPS P8700 Programmer's Guide]
 |===
 
 NOTE: Vendor extension names are case-insensitive, CamelCase is used here

--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -323,6 +323,7 @@ separated by a dot, e.g., `th.vxrm`.
 |Tenstorrent            | tt              | https://www.tenstorrent.com/
 |Ventana Micro Systems  | vt              | https://www.ventanamicro.com/
 |Nuclei                 | xl              | https://nucleisys.com/
+|MIPS                   | mips            | https://mips.com/
 |===
 
 NOTE: Vendor prefixes are case-insensitive.
@@ -377,6 +378,8 @@ tag to provide extra relocations for a given vendor.
 |T-Head  | XTheadSync      | 1.0            | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |T-Head  | XTheadVector    | 1.0            | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |Ventana | XVentanaCondOps | 1.0            | https://github.com/ventanamicro/ventana-custom-extensions/releases/download/v1.0.0/ventana-custom-extensions-v1.0.0.pdf[VTx-family custom instructions]
+|MIPS    | Xmipscmove      | 1.0            | https://mips.com/products/hardware/p8700/[MIPS p8700 specification]
+|MIPS    | Xmipslsp        | 1.0            | https://mips.com/products/hardware/p8700/[MIPS p8700 specification]
 |===
 
 NOTE: Vendor extension names are case-insensitive, CamelCase is used here


### PR DESCRIPTION
Adding extensions for MIPS vendor:
    1. xmipscmov
    2. xmipslsp
    3. xmipscbop
    4. xmipsexectl
    
The official product page here:
https://mips.com/products/hardware/p8700/
    
 Upstreaming of this in LLVM and binutils is in progress.
