### PR TITLE
Propose vendor mnemonic extension for CHERIoT

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -277,6 +277,7 @@ separated by a dot, e.g., `th.vxrm`.
 [%autowidth]
 |===
 |*Vendor*              |*Prefix*         |*URL*
+|Cheriot                | ct              | https://cheriot.org/
 |Open Hardware Group    | cv              | https://www.openhwgroup.org/
 |Andes                  | nds             | https://www.andestech.com/
 |SiFive                 | sf              | https://www.sifive.com/


### PR DESCRIPTION
Cheriot (https://cheriot.org/) is a RISC-V-based microcontroller platform that incorporates CHERI technology for capability-based security. It extends RISC-V with several new instructions (found in the ISA reference on cheriot.org). Some of these share names with the Zcheri extension currently under consideration, but do not use the same encodings, and thus should be in a vendor prefix.

The Cheriot LLVM toolchain is maintained in https://github.com/cherIoT-Platform/llvm-project It does not currently use a prefix on its custom instructions, but we would like to change that if we can assign a prefix.