### PR TITLE
Introduce vendor prefix for Rivos custom extensions

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -280,6 +280,7 @@ separated by a dot, e.g., `th.vxrm`.
 |Cheriot                | ct              | https://cheriot.org/
 |Open Hardware Group    | cv              | https://www.openhwgroup.org/
 |Andes                  | nds             | https://www.andestech.com/
+|Rivos                  | rv              | https://www.rivosinc.com/
 |SiFive                 | sf              | https://www.sifive.com/
 |T-Head                 | th              | https://www.t-head.cn/
 |Tenstorrent            | tt              | https://www.tenstorrent.com/

--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -280,7 +280,7 @@ separated by a dot, e.g., `th.vxrm`.
 |Cheriot                | ct              | https://cheriot.org/
 |Open Hardware Group    | cv              | https://www.openhwgroup.org/
 |Andes                  | nds             | https://www.andestech.com/
-|Rivos                  | rv              | https://www.rivosinc.com/
+|Rivos                  | ri              | https://www.rivosinc.com/
 |SiFive                 | sf              | https://www.sifive.com/
 |T-Head                 | th              | https://www.t-head.cn/
 |Tenstorrent            | tt              | https://www.tenstorrent.com/


### PR DESCRIPTION
This change reserves the vendor prefix "ri." for Rivos's custom extensions.