### PR TITLE
Added Qualcomm vendor prefix

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -314,6 +314,7 @@ separated by a dot, e.g., `th.vxrm`.
 |Cheriot                | ct              | https://cheriot.org/
 |Open Hardware Group    | cv              | https://www.openhwgroup.org/
 |Andes                  | nds             | https://www.andestech.com/
+|Qualcomm               | qc              | https://www.qualcomm.com/
 |Rivos                  | ri              | https://www.rivosinc.com/
 |SiFive                 | sf              | https://www.sifive.com/
 |SpacemiT               | smt             | https://www.spacemit.com/


### PR DESCRIPTION
Defined a vendor prefix for Qualcomm Microcontroller Extensions.

Qualcomm extensions are public and defined at
https://github.com/quic/riscv-unified-db/releases

The list of extensions will be added in separate commit.

Support for these extensions in the LLVM toolchain is also in progress.

Change-Id: I59b4c7c7e01f44f27e0255a21a6f9650c70d75ee