### PR TITLE
profiles: Move and tweak the profiles section

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -62,6 +62,36 @@ and `rv64`.
 such as `rv32gXfirstext_Xsecondext`. In GCC or Clang it would be more
 conventional to give a string such as `rv32g+firstext+secondext`.
 
+== Specifying the target profile with -march
+
+Similar to the target ISA, the `-march` flag can be used to set the target
+profile. A RISC-V profile is a ratified set of extensions with a unique name.
+
+The `-march` flag accepts the following form when specifying a target profile:
+  `"-march="<profile-name>["_"option-ext]*`
+
+`profile-name ::= 'profile-name-in-lowercase'`
+
+`option-ext ::= 'a legal RISC-V extension name'`
+
+For a list of valid RISC-V profile names refer to the
+https://github.com/riscv/riscv-profiles[RISC-V profile specification],
+which also discusses the naming convention.
+
+To distinguish between the target ISA and the target profile base formats
+for the `-march` flag, profiles need to be placed at the beginning of
+the string, and may be followed by additional extensions.
+This means that the string provided to the `-march` flag begins either
+with a ISA base or a profile.
+
+Examples:
+
+`-march=rvi20u64` equals `-march=rv64i`
+
+`-march=rvi20u64_zbkb_zkne` equals `-march=rv64i_zbkb_zkne`
+
+`-march=rva22u64` equals `-march=rv64gcb_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_zicclsm_ziccrse_zicntr_zihpm_za64rs_zfhmin_zkt`
+
 == Specifying the target ABI with -mabi
 
 - https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc#abi-ilp32[`ilp32`]:
@@ -249,35 +279,6 @@ register order from `s0` to `s11`. This follows the [Frame Pointer
 Convention](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc#frame-pointer-convention),
 whether or not a frame pointer is actually being used, and contradicts with the
 order used by Zcmp push/pop instructions.
-
-== Profile-based format
-
-Profile names will be a valid list of released profiles, it should be recognized and used
-in the `-march=` option. The benefit of using the `-march` option is easy for toolchain
-parsing the profiles string and expanding it into normal extensions combinations. 
-
-Profiles format has the following BNF form `"-march="<profile-name>["_"option-ext]*`.
-
-`profile-name ::= 'profile-name-in-lowercase'`
-
-`option-ext ::= 'a legal RISC-V extension name'`
-
-According to the specification, profiles must adhere to the defined naming format
-for proper usage.(See [3.4 from spec doc](https://github.com/riscv/riscv-profiles)).
-The toolchain will check whether an input profile name is correct first, then do
-the parse work.
-
-To distinguish between ordinary extension input and input with profiles,
-profiles are assumed to be entered *at the beginning of the -march option*, and
-then input other extensions.
-
-Examples:
-
-`-march=rvi20u64` equals `-march=rv64i`
-
-`-march=rvi20u64_zbkb_zkne` equals `-march=rv64i_zbkb_zkne`
-
-`-march=rva22u64` equals `-march=rv64gcb_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_zicclsm_ziccrse_zicntr_zihpm_za64rs_zfhmin_zkt`
 
 == Conventions for vendor extensions
 


### PR DESCRIPTION
This moves the profiles section right after the target ISA section as both explain the behavior of the -march flag.
Further, the wording is a bit tweaked.
No changes on the feature level of the profile support.