### PR TITLE
Vendor extensions: Add 'XTheadVdot' T-Head vendor extensions

### DIFF
--- a/src/appendix.adoc
+++ b/src/appendix.adoc
@@ -37,6 +37,7 @@ before modifying this table.
 |T-Head  | XTheadMemIdx    | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |T-Head  | XTheadSync      | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |T-Head  | XTheadVector    | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
+|T-Head  | XTheadVdot      | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |Ventana | XVentanaCondOps | https://github.com/ventanamicro/ventana-custom-extensions/releases/download/v1.0.0/ventana-custom-extensions-v1.0.0.pdf[VTx-family custom instructions]
 |===
 


### PR DESCRIPTION
This patch defines the T-Head vendor extensions (XTheadVdot), which is documented here:
  https://github.com/T-head-Semi/thead-extension-spec