### PR TITLE
Add Andes vendor identifier

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -376,6 +376,7 @@ tag to provide extra relocations for a given vendor.
 [%autowidth]
 |===
 |*Vendor*              |*Symbol*
+|Andes                 | ANDES
 |Open Hardware Group   | COREV
 |Qualcomm              | QUALCOMM
 |===


### PR DESCRIPTION
The vendor identifier for Andes was added to LLVM
https://github.com/llvm/llvm-project/pull/137748.