### PR TITLE
Add Andes Vendor extensions

### DIFF
--- a/src/appendix.adoc
+++ b/src/appendix.adoc
@@ -9,6 +9,11 @@ before modifying this table.
 |===
 |*Vendor*  |*Name*         |*ISA Document*
 |Andes   | XAndesPerf      | https://github.com/andestech/andes-v5-isa/releases/tag/ast-v5_4_0-release[Andes Instruction Extension Specification]
+|Andes   | XAndesBFHCvt    | https://github.com/andestech/andes-v5-isa/releases/tag/ast-v5_4_0-release[Andes Instruction Extension Specification]
+|Andes   | XAndesVBFHCvt   | https://github.com/andestech/andes-v5-isa/releases/tag/ast-v5_4_0-release[Andes Instruction Extension Specification]
+|Andes   | XAndesVSIntLoad | https://github.com/andestech/andes-v5-isa/releases/tag/ast-v5_4_0-release[Andes Instruction Extension Specification]
+|Andes   | XAndesVPackFPH  | https://github.com/andestech/andes-v5-isa/releases/tag/ast-v5_4_0-release[Andes Instruction Extension Specification]
+|Andes   | XAndesVDot      | https://github.com/andestech/andes-v5-isa/releases/tag/ast-v5_4_0-release[Andes Instruction Extension Specification]
 |MIPS    | Xmipscmov       | https://mips.com/wp-content/uploads/2025/03/P8700-F_Programmers_Reference_Manual_Rev1.82_3-19-2025.pdf[MIPS P8700 Programmer's Guide]
 |MIPS    | Xmipslsp        | https://mips.com/wp-content/uploads/2025/03/P8700-F_Programmers_Reference_Manual_Rev1.82_3-19-2025.pdf[MIPS P8700 Programmer's Guide]
 |OpenHW  | Xcvalu          | https://github.com/openhwgroup/cv32e40p/blob/dev/docs/source/instruction_set_extensions.rst[CORE-V Instruction Set Extensions]


### PR DESCRIPTION
These extensions have been supported in LLVM and is in progess in gcc.