### PR TITLE
Add documentation for the new `-mtune` syntax

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -272,15 +272,13 @@ This _non-overlapping_ rule is a deliberate decision to simplify the logic and p
 this from becoming unmanageable in the future.
 
 === List of common tuning features
-Here is a list of tuning features shared by GCC and Clang at this moment. Each entry
+Here is a list of tuning feature(s) shared by GCC and Clang at this moment. Each entry
 starts with `<positive directive name> / <negative directive name>`, followed by
 description of the performance characteristics enabled by the positive directive.
 
 - `short-forward-branch-opt` / `no-short-forward-branch-opt`: Has short forward branch
 optimization, which effectively predicates instructions of certain types that follow
 immediately after a forward branch.
-- `optimized-zero-stride-load` / `no-optimized-zero-stride-load`: Vector strided loads
-with zero stride perform fewer memory operations.
 
 == Disassembler (objdump) behaviour
 


### PR DESCRIPTION
This PR documents a new `-mtune` syntax that allows users to describe the tuning features using a combination of "base" tuning CPU + feature directives. This new syntax reflects RISC-V's highly configurable nature and makes it easier for users to share the same compiler across a wide variety of RISC-V cores.

Questions for the folks: should we document, in the same file, all the tuning directive names -- which are supposed to be public interface -- we have in LLVM right now? Or should we put it somewhere else?

-----
References:
  - https://github.com/llvm/llvm-project/pull/162716 : the original discussion on customizing tuning CPU
  - https://github.com/llvm/llvm-project/pull/168160 : LLVM implementation of this new syntax