### PR TITLE
Add WCH Vendor extension

### DIFF
--- a/src/appendix.adoc
+++ b/src/appendix.adoc
@@ -63,6 +63,7 @@ before modifying this table.
 |T-Head  | XTheadVector    | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |T-Head  | XTheadVdot      | https://github.com/T-head-Semi/thead-extension-spec/releases/latest[T-Head ISA extension specification]
 |Ventana | XVentanaCondOps | https://github.com/ventanamicro/ventana-custom-extensions/releases/download/v1.0.0/ventana-custom-extensions-v1.0.0.pdf[VTx-family custom instructions]
+|Qinheng | XWchc           | http://web.archive.org/web/20251121133229/https://discourse.llvm.org/t/rfc-supporting-wch-qingke-xw-compressed-opcodes/79392/12[Encoding of XW compressed opcodes]
 |===
 
 NOTE: Vendor extension names are case-insensitive, CamelCase is used here

--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -406,6 +406,7 @@ before modifying this table.
 |T-Head                 | th              | https://www.t-head.cn/
 |Tenstorrent            | tt              | https://www.tenstorrent.com/
 |Ventana Micro Systems  | vt              | https://www.ventanamicro.com/
+|Qinheng                | wch             | https://www.wch.cn/
 |===
 
 NOTE: Vendor prefixes are case-insensitive.


### PR DESCRIPTION
This extension has been merged to LLVM [3c5f929](https://github.com/llvm/llvm-project/commit/3c5f929) and WIP in GCC/binutils.