### PR TITLE
Introduce a new vendor prefix for AIFoundry

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -392,7 +392,8 @@ before modifying this table.
 .List of vendor prefixes
 [%autowidth]
 |===
-|*Vendor*              |*Prefix*         |*URL*
+|*Vendor*               |*Prefix*         |*URL*
+|AIFoundry              | aif             | https://aifoundry.org/
 |Andes                  | nds             | https://www.andestech.com/
 |Cheriot                | ct              | https://cheriot.org/
 |Espressif              | esp             | https://www.espressif.com/


### PR DESCRIPTION
AIFoundry is a non-profit organization dedicated to advancing open-source AI infrastructure. It supports multiple open-source projects, including the et-platform software stack that underpins Ai Nekko’s Erbium and the legacy Esperanto Technologies’ ET-SoC-1.