### PR TITLE
Add "xt" prefix for Xuantie vendor extension

### DIFF
--- a/src/toolchain-conventions.adoc
+++ b/src/toolchain-conventions.adoc
@@ -407,6 +407,7 @@ before modifying this table.
 |T-Head                 | th              | https://www.t-head.cn/
 |Tenstorrent            | tt              | https://www.tenstorrent.com/
 |Ventana Micro Systems  | vt              | https://www.ventanamicro.com/
+|Xuantie                | xt              | https://www.xrvm.cn/
 |===
 
 NOTE: Vendor prefixes are case-insensitive.
@@ -414,6 +415,8 @@ NOTE: Vendor prefixes are case-insensitive.
 NOTE: The Nuclei instruction prefix `xl` is an abbreviation of "XinLai", which is the Chinese pronunciation of Nuclei(`+芯来+`).
 
 NOTE: OpenHW cores are all branded as CORE-V, hence the prefix.
+
+NOTE: Xuantie, which defined the XThead vendor extensions, was one of T-Head products but now separated out.
 
 === List of vendor identifiers
 Vendor identifiers are dummy symbols used in the corresponding `R_RISCV_VENDOR`


### PR DESCRIPTION
This patch is adding "xt" to the list of vendor prefixes. 
The relationship between "xt" and "th" has been added in the "NOTE".