### PR TITLE
Use ghcr.io/riscv/riscv-docs-base-container-image:latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DOCS := \
 	riscv-toolchain.adoc
 
 DATE ?= $(shell date +%Y-%m-%d)
-DOCKER_IMG := riscvintl/riscv-docs-base-container-image:latest
+DOCKER_IMG := ghcr.io/riscv/riscv-docs-base-container-image:latest
 
 ifneq ($(SKIP_DOCKER),true)
 	DOCKER_CMD := docker run --rm -v ${PWD}:/build -w /build \


### PR DESCRIPTION
This updates the docs container image reference in the root Makefile.

The old `riscvintl` image has been replaced with the `ghcr.io/riscv` image.
